### PR TITLE
Update README.md - install cargo-playdate

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 ## initial setup
 
 ```console
-cargo search
-cargo install --git="https://github.com/boozook/playdate.git" cargo-playdate --bin=cargo-playdate
+cargo install cargo-playdate
 ```
 
 TODO: do this in the flake


### PR DESCRIPTION
Install cargo-playdate from crates.io is better, preferable way, stable + semver.